### PR TITLE
请升级io.netty:netty-codec-http2组件版本以解决2个安全漏洞

### DIFF
--- a/dubbo-dependencies-bom/pom.xml
+++ b/dubbo-dependencies-bom/pom.xml
@@ -134,7 +134,7 @@
         <tomcat_embed_version>8.5.69</tomcat_embed_version>
         <jetcd_version>0.5.3</jetcd_version>
         <nacos_version>2.0.4</nacos_version>
-        <grpc.version>1.31.1</grpc.version>
+        <grpc.version>1.45.0</grpc.version>
         <!-- Log libs -->
         <slf4j_version>1.7.25</slf4j_version>
         <jcl_version>1.2</jcl_version>


### PR DESCRIPTION
通过murphysec.com提交PR来修复安全漏洞